### PR TITLE
feat(mobile): "you might like" section

### DIFF
--- a/modules/apps/mobile/src/home/containers/TrackSuggestionsSection.vue
+++ b/modules/apps/mobile/src/home/containers/TrackSuggestionsSection.vue
@@ -19,7 +19,7 @@
 <script setup lang="ts">
 import { useAsyncState } from '@vueuse/core'
 import { IonList } from '@ionic/vue'
-import { mapTrackToPlaylistItem, SectionHeader } from '@/home'
+import { mapTrackToPlaylistItem, SectionHeader, useUserSeesSuggestionsScenario } from '@/home'
 import { TracksListItem, type TracksListItemData, useConfig } from '@/app'
 import { useDAL } from '@/app'
 
@@ -29,6 +29,7 @@ import { useDAL } from '@/app'
 
 const dal = useDAL()
 const config = useConfig()
+const userSeesSuggestions = useUserSeesSuggestionsScenario()
 
 /* -------------------------------------------------------------------------- */
 /*                                    State                                   */
@@ -51,7 +52,7 @@ defineExpose({ refresh })
 
 async function getSuggestions() : Promise<TracksListItemData[]> {
   try {
-    const suggestedTracks = await dal.tracks.getAll()
+    const suggestedTracks = await userSeesSuggestions.execute()
     return await Promise.all(
       suggestedTracks.map(x => mapTrackToPlaylistItem(x, config.appLanguage.value))
     )

--- a/modules/apps/mobile/src/home/index.ts
+++ b/modules/apps/mobile/src/home/index.ts
@@ -18,6 +18,7 @@ export { default as UpNextTracksSection } from './containers/UpNextTracksSection
 export * from './scenarios/useUserSeesUpNextTracksScenario'
 export * from './scenarios/useUserSelectsTrackToPlayScenario'
 export * from './scenarios/useUserRemovesPlaylistItemScenario'
+export * from './scenarios/useUserSeesSuggestionsScenario'
 
 // mappers:
 export { mapTrackToPlaylistItem } from './mappers/tracks'

--- a/modules/apps/mobile/src/home/scenarios/useUserSeesSuggestionsScenario.ts
+++ b/modules/apps/mobile/src/home/scenarios/useUserSeesSuggestionsScenario.ts
@@ -24,13 +24,11 @@ export function useUserSeesSuggestionsScenario() {
     const totalTracksCount = await dal.tracks.getCount()
 
     // TODO: make the unique
-    // Generate array with random ids -> from 1 to trackScount
+    // Generate array with random ids -> from 1 to tracksCount
     const randomTrackIds = [...new Set(Array.from(
       { length: max }, 
       () => Math.floor(Math.random() * totalTracksCount) + 1
     ))]
-
-    console.log(randomTrackIds)
 
     // Load tracks by that ids, filter out if nothing found
     const tracks = await Promise.all(

--- a/modules/apps/mobile/src/home/scenarios/useUserSeesSuggestionsScenario.ts
+++ b/modules/apps/mobile/src/home/scenarios/useUserSeesSuggestionsScenario.ts
@@ -1,0 +1,51 @@
+import { useDAL } from '@/app'
+import Sqids from 'sqids'
+
+export function useUserSeesSuggestionsScenario() {
+  /* -------------------------------------------------------------------------- */
+  /*                                Dependencies                                */
+  /* -------------------------------------------------------------------------- */
+
+  const dal = useDAL()
+  const sqids = new Sqids({ minLength: 10 })
+
+  /* -------------------------------------------------------------------------- */
+  /*                                  Handlers                                  */
+  /* -------------------------------------------------------------------------- */
+
+  /**
+   * Fetches a specified number of random track suggestions for the user.
+   * @param max - The maximum number of track suggestions to fetch. Defaults to 5.
+   * @returns A Promise that resolves to an array of track objects. Any tracks that couldn't be found are filtered out.
+   */
+  async function execute(max: number = 5) {
+    // Get total tracks count
+    const totalTracksCount = await dal.tracks.getCount()
+
+    // TODO: make the unique
+    // Generate array with random ids -> from 1 to trackScount
+    const randomTrackIds = new Set(Array.from(
+      { length: max }, 
+      () => Math.floor(Math.random() * totalTracksCount) + 1
+    )).values()
+
+    console.log(randomTrackIds)
+
+    // Load tracks by that ids, filter out if nothing found
+    const tracks = await Promise.all(
+      randomTrackIds.map(
+        async id => await dal.tracks.findOne({ _id: sqids.encode([id]) })
+      )
+    )
+
+    // List of tracks
+    return tracks.filter(track => track !== undefined)
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                                  Interface                                 */
+  /* -------------------------------------------------------------------------- */
+
+  return { execute }
+  
+}

--- a/modules/apps/mobile/src/home/scenarios/useUserSeesSuggestionsScenario.ts
+++ b/modules/apps/mobile/src/home/scenarios/useUserSeesSuggestionsScenario.ts
@@ -1,4 +1,5 @@
 import { useDAL } from '@/app'
+import { Track } from '@lectorium/dal/models'
 import Sqids from 'sqids'
 
 export function useUserSeesSuggestionsScenario() {
@@ -18,16 +19,16 @@ export function useUserSeesSuggestionsScenario() {
    * @param max - The maximum number of track suggestions to fetch. Defaults to 5.
    * @returns A Promise that resolves to an array of track objects. Any tracks that couldn't be found are filtered out.
    */
-  async function execute(max: number = 5) {
+  async function execute(max: number = 5): Promise<Track[]> {
     // Get total tracks count
     const totalTracksCount = await dal.tracks.getCount()
 
     // TODO: make the unique
     // Generate array with random ids -> from 1 to trackScount
-    const randomTrackIds = new Set(Array.from(
+    const randomTrackIds = [...new Set(Array.from(
       { length: max }, 
       () => Math.floor(Math.random() * totalTracksCount) + 1
-    )).values()
+    ))]
 
     console.log(randomTrackIds)
 
@@ -39,7 +40,7 @@ export function useUserSeesSuggestionsScenario() {
     )
 
     // List of tracks
-    return tracks.filter(track => track !== undefined)
+    return tracks.filter((track): track is Track => track != undefined)
   }
 
   /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This pull request introduces a new feature to fetch random track suggestions for users and integrates it into the `TrackSuggestionsSection` component. The changes include the creation of a new scenario, `useUserSeesSuggestionsScenario`, and updates to the logic for retrieving track suggestions. Below are the most important changes grouped by theme:

### New Feature: Random Track Suggestions
* **`useUserSeesSuggestionsScenario` implementation**: Added a new scenario in `modules/apps/mobile/src/home/scenarios/useUserSeesSuggestionsScenario.ts` to fetch a specified number of random track suggestions using `useDAL` and `Sqids`. This includes generating random track IDs, fetching tracks by those IDs, and filtering out undefined results.

### Integration into `TrackSuggestionsSection`
* **Import of `useUserSeesSuggestionsScenario`**: Updated imports in `TrackSuggestionsSection.vue` to include the new `useUserSeesSuggestionsScenario` function.
* **Initialization of `userSeesSuggestions`**: Added initialization of the `useUserSeesSuggestionsScenario` function in `TrackSuggestionsSection.vue`.
* **Updated track fetching logic**: Replaced the call to `dal.tracks.getAll()` with `userSeesSuggestions.execute()` to use the new random track suggestion logic.

### Export for Reusability
* **Export of `useUserSeesSuggestionsScenario`**: Added export for the new scenario in `modules/apps/mobile/src/home/index.ts` to make it accessible across the app.